### PR TITLE
feat: Supabase JWT検証ミドルウェアを追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 SUPABASE_URL="https://xxxx.supabase.co"
 SUPABASE_SERVICE_ROLE_KEY="your_service_role_key" # 秘密キーなので漏洩に注意
+SUPABASE_JWT_SECRET="your_JWT_secret_key"
 
 GITHUB_CLIENT_ID="your_github_oauth_client_id"
 GITHUB_CLIENT_SECRET="your_github_oauth_client_secret" # 秘密キーなので漏洩に注意

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ go.work.sum
 # Editor/IDE
 # .idea/
 # .vscode/
+
+generate_jwt.go

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/gorilla/mux"
+	"github.com/joho/godotenv"
+	"github.com/progate-hackathon-strawberry-flavor/GITRIS-backend/internal/handlers"
+)
+
+func main(){
+	if os.Getenv("APP_ENV") != "production"{
+		err := godotenv.Load()
+		if err != nil {
+			log.Printf("warning: Error loading .env file (this is fine in production): %v", err)
+		}
+	}
+
+	r := mux.NewRouter()
+	r.HandleFunc("/api/public", handlers.PublicHandler).Methods("GET")
+
+	// 認証が必要なルートグループを作成
+	// PathPrefix を使用して、特定のパスから始まるURLにのみミドルウェアを適用できます。
+	// 例えば、/api/protected/ で始まる全てのパスにAuthMiddlewareを適用します。
+	protectedRouter := r.PathPrefix("/api/protected").Subrouter()
+	protectedRouter.Use(handlers.AuthMiddleware)
+
+	// 認証が必要なエンドポイント
+	protectedRouter.HandleFunc("/decks", handlers.GetDecksForUser).Methods("GET")
+
+	port := os.Getenv("PORT")
+	if port == ""{
+		port = "8080"
+	}
+	log.Printf("Server starting on :%s", port)
+	log.Fatal(http.ListenAndServe(":"+port, r))
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/progate-hackathon-strawberry-flavor/GITRIS-backend
 go 1.24.1
 
 require (
+	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
 	github.com/google/go-github/v59 v59.0.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
+github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-github/v59 v59.0.0 h1:7h6bgpF5as0YQLLkEiVqpgtJqjimMYhBkD4jT5aN3VA=
 github.com/google/go-github/v59 v59.0.0/go.mod h1:rJU4R0rQHFVFDOkqGWxfLNo6vEk4dv40oDjhV/gH6wM=

--- a/internal/handlers/auth_middleware.go
+++ b/internal/handlers/auth_middleware.go
@@ -1,0 +1,89 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+type UserIDKey struct{}
+
+func AuthMiddleware(next http.Handler) http.Handler{
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request){
+		// 1. authorizationヘッダーからJWTを取得
+		authHeader := r.Header.Get("Authorization")
+		if authHeader ==""{
+			http.Error(w, "Authorization header is requred", http.StatusUnauthorized)
+			return
+		}
+
+		tokenString := ""
+		if len(authHeader) > 7 && authHeader[0:7] == "Bearer "{
+			tokenString = authHeader[7:]
+		} else {
+			http.Error(w, "Invalid Authorization header format. Must be 'Bearer <token>'",
+			http.StatusUnauthorized)
+			return
+		}
+
+		// 2. JWT Secretを取得
+		jwtSecret := os.Getenv("SUPABASE_JWT_SECRET")
+		if jwtSecret == ""{
+			log.Println("Error: SUPABASE_JWT_SECRET environment variable is not set.")
+			http.Error(w, "Server configuration error: JWT secret missing", http.StatusInternalServerError)
+			return
+		}
+
+		// JWTの検証とパース
+		token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error){
+			// アルゴリズムがHMACであることを確認
+			if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+				return nil, fmt.Errorf("unexpected igning method: %v", token.Header["alg"])
+			}
+			// Secret Keyを返す
+			return []byte(jwtSecret), nil
+		})
+
+		if err != nil {
+			log.Printf("JWT parsing error: %v", err)
+			http.Error(w, "Invalid token format or signature", http.StatusUnauthorized)
+			return
+		}
+
+		// 4. トークンが有効であることを確認
+		if !token.Valid {
+			http.Error(w, "Invalid token", http.StatusUnauthorized)
+			return
+		}
+
+		// 5. クレーム（ペイロード）からユーザーIDを取得
+		claims, ok := token.Claims.(jwt.MapClaims)
+		if !ok {
+			http.Error(w, "Invalid token claims format", http.StatusUnauthorized)
+			return
+		}
+
+		// SupabaseのJWTは通常、ユーザーIDを 'sub' (Subject) クレームにUUIDとして格納します。
+		userID, ok := claims["sub"].(string) 
+		if !ok {
+			log.Printf("JWT claims missing 'sub' (userID) or wrong type: %v", claims["sub"])
+			http.Error(w, "User ID not found in token", http.StatusUnauthorized)
+			return
+		}
+
+		// 6. ユーザーIDをContextに設定して次のハンドラに渡す
+		// ContextにユーザーIDを設定することで、次のハンドラ関数で安全に取得できます。
+		ctx := context.WithValue(r.Context(), UserIDKey{}, userID) 
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// HTTPリクエストのContextからユーザーIDを取得する関数（ヘルパー）
+func GetUserIDFromContext(ctx context.Context)(string, bool){
+	userID, ok := ctx.Value(UserIDKey{}).(string)
+	return userID, ok
+}

--- a/internal/handlers/auth_middleware.go
+++ b/internal/handlers/auth_middleware.go
@@ -17,7 +17,7 @@ func AuthMiddleware(next http.Handler) http.Handler{
 		// 1. authorizationヘッダーからJWTを取得
 		authHeader := r.Header.Get("Authorization")
 		if authHeader ==""{
-			http.Error(w, "Authorization header is requred", http.StatusUnauthorized)
+			http.Error(w, "Authorization header is required", http.StatusUnauthorized)
 			return
 		}
 

--- a/internal/handlers/auth_middleware.go
+++ b/internal/handlers/auth_middleware.go
@@ -42,7 +42,7 @@ func AuthMiddleware(next http.Handler) http.Handler{
 		token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error){
 			// アルゴリズムがHMACであることを確認
 			if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
-				return nil, fmt.Errorf("unexpected igning method: %v", token.Header["alg"])
+				return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 			}
 			// Secret Keyを返す
 			return []byte(jwtSecret), nil

--- a/internal/handlers/deck_handler.go
+++ b/internal/handlers/deck_handler.go
@@ -1,0 +1,43 @@
+// backend/internal/handlers/deck_handler.go (保護されたハンドラの例)
+package handlers
+
+// ログインが必要なAPI検証のために一旦おいてる。
+// 実際のDeckではない
+
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	// "your_project_name/backend/internal/services" // ビジネスロジックを担うサービス層
+	// ここに Supabase と連携するためのコードや、デッキデータを扱うためのロジックを実装します。
+)
+
+// GetDecksForUser は、認証されたユーザーのデッキリストを返すハンドラ関数です。
+func GetDecksForUser(w http.ResponseWriter, r *http.Request) {
+	// ContextからユーザーIDを取得
+	userID, ok := GetUserIDFromContext(r.Context())
+	if !ok {
+		// ミドルウェアが正しく動作していれば、ここには到達しないはずですが、念のため
+		log.Println("Error: User ID not found in context for GetDecksForUser")
+		http.Error(w, "ログインしてから出直してこい！", http.StatusUnauthorized)
+		return
+	}
+
+	log.Printf("Request from authenticated user: %s", userID)
+
+	// ここで userID を使用して、データベースからそのユーザーのデッキを取得するなどの
+	// ビジネスロジックを実行します。
+	// 例:
+	// decks, err := services.DeckService.GetDecksByUserID(userID)
+	// if err != nil {
+	//     http.Error(w, "Failed to retrieve decks", http.StatusInternalServerError)
+	//     return
+	// }
+	// json.NewEncoder(w).Encode(decks) // デッキをJSONとして返す
+
+	// 現時点では、簡易的なレスポンスを返します。
+	w.Header().Set("Content-Type", "text/plain") // Content-Type を設定
+	fmt.Fprintf(w, "やあ。ここはJWTトークン持っている人専用のAPIだよ。貴様、ログインしているな？", userID)
+}
+

--- a/internal/handlers/deck_handler.go
+++ b/internal/handlers/deck_handler.go
@@ -38,6 +38,6 @@ func GetDecksForUser(w http.ResponseWriter, r *http.Request) {
 
 	// 現時点では、簡易的なレスポンスを返します。
 	w.Header().Set("Content-Type", "text/plain") // Content-Type を設定
-	fmt.Fprintf(w, "やあ。ここはJWTトークン持っている人専用のAPIだよ。貴様、ログインしているな？", userID)
+	fmt.Fprintf(w, "やあ。ここはJWTトークン持っている人専用のAPIだよ。貴様、ログインしているな？ユーザーID: %s", userID)
 }
 

--- a/internal/handlers/public_handler.go
+++ b/internal/handlers/public_handler.go
@@ -1,6 +1,6 @@
 package handlers
 
-import(
+import (
 	"net/http"
 	"log"
 	"fmt"

--- a/internal/handlers/public_handler.go
+++ b/internal/handlers/public_handler.go
@@ -1,0 +1,13 @@
+package handlers
+
+import(
+	"net/http"
+	"log"
+	"fmt"
+)
+
+func PublicHandler(w http.ResponseWriter, r *http.Request) {
+	log.Println("Request to public endpoint: /api/public")
+	w.Header().Set("Content-Type", "text/plain")
+	fmt.Fprintf(w, "Hello, this is public content! (From /api/public)")
+}


### PR DESCRIPTION
## 概要
Supabase Authで認証されたユーザーからのリクエストに対し、JWTを検証し、安全にユーザーIDを抽出するミドルウェアを追加した。
これにより、APIエンドポイントを認証済みユーザー向けに保護し、リクエスト元ユーザーを特定できるようになる。

## 変更点

-   **`backend/internal/handlers/auth_middleware.go`**: JWT検証ロジックとユーザーIDのContextへの格納を実装。
-   **`backend/internal/handlers/deck_handler.go`**: 認証されたユーザーIDを利用するAPIハンドラの例を更新。
-   **`backend/cmd/api/main.go`**: ルーターに認証ミドルウェアを適用し、`/api/protected` エンドポイントを保護。開発環境向けに`.env`読み込みを追加。

## 動作確認

以下の`curl`コマンドで動作を確認しました。

1.  **公開エンドポイント**:
    ```bash
    curl http://localhost:8080/api/public
    ```
    **結果**: 公開コンテンツが表示される。

2.  **保護されたエンドポイント (認証なし)**:
    ```bash
    curl http://localhost:8080/api/protected/decks
    ```
    **結果**: `401 Unauthorized` エラー (`Authorization header is required`)。

3.  **保護されたエンドポイント (無効なJWT)**:
    ```bash
    curl -H "Authorization: Bearer invalid-jwt-token" http://localhost:8080/api/protected/decks
    ```
    **結果**: `401 Unauthorized` エラー (`Invalid token format or signature`)。

4.  **保護されたエンドポイント (有効なJWT)**:
    -   Supabaseで取得した実際のJWTトークンを使用。
    ```bash
    curl -H "Authorization: Bearer YOUR_ACTUAL_SUPABASE_JWT" http://localhost:8080/api/protected/decks
    ```
    **結果**: ユーザーIDを含む保護されたコンテンツが表示される。

# 以下、Copilotに知っておいてほしいこと （消さないでね！）
<!-- I want to review in Japanese. -->
<!-- for GitHub Copilot review rule -->
<!--
レビューする際には、以下のprefix(接頭辞)をつけてください
[must]  
[imo] (in my opinion)  
[nits](nitpick) 
[ask]  
[fyi]
-->
<!-- レビューする際は、いちご大好きな可愛い女子大学生らしいくだけた口調を心がけ、時々語尾に「🍓」をつけるようにしてください。 -->
<!-- 悪い例：「このPRはREADME.mdの内容更新を目的としています🍓」 -->
<!-- より良い例：「このプルリクは、README.mdの内容更新を目的としているよ！🍓」 -->
<!-- 
レビュー者としてのあなた：
- ポジティブで建設的なコミュニケーションを心がけます
- 技術的な問題点は明確に指摘しつつも、相手を尊重する表現を使います
- チームの雰囲気作りを大切にし、メンバーのモチベーション向上に貢献します
 -->
<!-- for GitHub Copilot review  rule-->
<!-- I want to review in Japanese. -->